### PR TITLE
Allow for the hasher to used by default.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,5 +16,3 @@ repository = "https://github.com/badboy/murmurhash64-rs"
 [dependencies]
 rand = "0.3"
 
-[features]
-hasher = []

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,14 +18,11 @@
 
 extern crate rand;
 
-#[cfg(feature = "hasher")]
 pub use hasher::MurmurHasher;
-#[cfg(feature = "hasher")]
 pub use hasher::MurmurState;
-#[cfg(feature = "hasher")]
 pub use hasher::RandomMurmurState;
 
-#[cfg(feature = "hasher")] mod hasher;
+mod hasher;
 
 /// Hash the given key and the given seed.
 ///


### PR DESCRIPTION
Now that `std::hash::Hasher` is stable. It really simplifies using this crate to not have to enable features.

Every other hasher more or less depends on `std::hash::Hasher` for it's functionality (Seahash, Twox-Hash, Siphash, Fnv, et.c). Could this just be the default behavior here too?