### PR TITLE
The murmur_hash64a function can be now called at compile time

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -41,7 +41,7 @@ mod hasher;
 ///
 /// let hash = murmur_hash64a(key.as_bytes(), seed);
 /// ```
-pub fn murmur_hash64a(key: &[u8], seed: u64) -> u64 {
+pub const fn murmur_hash64a(key: &[u8], seed: u64) -> u64 {
     let m : u64 = 0xc6a4a7935bd1e995;
     let r : u8 = 47;
 


### PR DESCRIPTION
I use this to define constants with hash values I can use at runtime as IDs. Maybe other will also find this useful :)